### PR TITLE
Add quotes to backgroundImage url

### DIFF
--- a/client/components/Screen.js
+++ b/client/components/Screen.js
@@ -34,7 +34,7 @@ const Screen = (props) => {
     case modes.SLIDE:
       const slideIndex = getShowProps(props.slide, show);
       const slide = slides[slideIndex];
-      if (slide) style.backgroundImage = `url(${slide.background})`;
+      if (slide) style.backgroundImage = `url("${slide.background}")`;
       break;
 
     case modes.VOICE:
@@ -44,7 +44,7 @@ const Screen = (props) => {
       if (voice.display) {
         const { background, fontFamily, fontColor, fontSize } = voice.display;
 
-        style.backgroundImage = `url(${voice.display.background})`;
+        style.backgroundImage = `url("${voice.display.background}")`;
         style.fontSize = fontSize;
         style.fontFamily = fontFamily;
         style.color = fontColor;


### PR DESCRIPTION
We were finding that some images refused to load into the [`Screen`](https://github.com/DoSomething/blockbuster/blob/master/client/components/Screen.js) properly, despite being set as the `backgroundImage`. 

We found that the issue was occurring with any URL that had a parenthesis in it.

Adding double quotes to wrap the URL ensures that it is actually attached as the style to the `Screen` component and seems to have resolved this issue!